### PR TITLE
Use brew link instead of manually symlinking ic4c

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,7 @@ After that, install `node-icu-charset-detector` from npm.
 
     ```shell
     brew install icu4c
-    ln -s /usr/local/Cellar/icu4c/<VERSION>/bin/icu-config /usr/local/bin/icu-config
-    ln -s /usr/local/Cellar/icu4c/<VERSION>/include/unicode /usr/local/include
+    brew link icu4c --force
     ```
 
     If experiencing issues with 'homebrew' installing version 50.1 of icu4c, try the following:


### PR DESCRIPTION
Simply using `brew link` instead of manually symlinking works as well, and is probably easier to maintain. The `--force` flag is needed because the ic4c library is marked as "keg only". I verified that it worked locally by `unlink`ing the old symlinks, `brew uninstall icu4c` and running these two commands.
