### PR TITLE
Attempt to make node-icu-charset-detector run under Heroku

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -5,7 +5,7 @@
       'sources': [ 'node-icu-charset-detector.cpp' ],
       'cflags!': [ '-fno-exceptions', '`icu-config --cppflags`' ],
       'cflags_cc!': [ '-fno-exceptions' ],
-      'libraries': [ '`icu-config --ldflags`' ],
+      'libraries': [ '`icu-config --detect-prefix --ldflags`' ],
       'include_dirs': [ "<!(node -e \"require('nan')\")" ],
       'conditions': [
         ['OS=="mac"', {


### PR DESCRIPTION
Hi,

I was trying to get the module deployed under Heroku and was getting undefined symbols during run time.

This change seems to fix it for Heroku and doesn't break it for local deployment.

Will be happy for any solution, I'm not sure whether this one doesn't have a downside.