### PR TITLE
added /usr/local/include reference

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -10,7 +10,8 @@
       'conditions': [
         ['OS=="mac"', {
           'include_dirs': [
-              '/opt/local/include'
+              '/opt/local/include',
+              '/usr/local/include'
           ],
           'xcode_settings': {
             'GCC_ENABLE_CPP_EXCEPTIONS': 'YES'


### PR DESCRIPTION
To avoid problems like:

```
../node-icu-charset-detector.cpp:7:10: fatal error: 'unicode/ucsdet.h' file not found
#include <unicode/ucsdet.h>
```

because the file is in another path!